### PR TITLE
fix(outputs): prevent errors when API Front Door is disabled

### DIFF
--- a/infra/instance/modules/api/outputs.tf
+++ b/infra/instance/modules/api/outputs.tf
@@ -5,7 +5,7 @@ output "api_app_service_url" {
 
 output "api_frontdoor_endpoint_url" {
   description = "Front Door default domain URL."
-  value       = "https://${one(azurerm_cdn_frontdoor_endpoint.api_fd_endpoint[*].host_name)}"
+  value       = try("https://${one(azurerm_cdn_frontdoor_endpoint.api_fd_endpoint[*].host_name)}", null)
 }
 output "api_frontdoor_endpoint_host_name" {
   description = "Front Door hostname (*.azurefd.net)."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please fill out the following template to help us review your PR. -->

# Description

<!-- Summarize your changes and the motivation behind them. Reference any related issues. -->
This PR adds a safety check to the `api_frontdoor_endpoint_url` output to prevent Terraform from crashing or throwing errors in environments where the API Front Door endpoint is not deployed.

### Changes
*   **Module Outputs**: Wrapped the `api_frontdoor_endpoint_url` logic in a `try()` function.
*   **Logic**: If the `api_fd_endpoint` resource is missing (due to a count of 0), the output will now gracefully return `null` instead of failing during the attribute lookup.

### Impact
This change is particularly important for conditional deployments or "lite" environments where the Front Door component is toggled off, ensuring `terraform apply` and `terraform output` commands remain stable.

## Related Issues/Tickets

<!-- List related issues or discussions, such as "Closes #123" or "Related to PADS-456" -->
[PSB-170](https://apps.nrs.gov.bc.ca/int/jira/browse/PSB-170)

## Type of Change

<!-- Please check all that apply: -->

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update

## Checklist

<!-- Please check all that apply: -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my changes locally
- [x] The code builds and passes all tests
- [x] I have updated documentation as needed

## Instance Deployment

<!-- Please check all that apply: -->

- [ ] I require a cloud deployment for testing

> [!NOTE]
> To request for a cloud deployment for testing purposes, add the `deploy` label to this PR.
> Deployments will be removed when the PR is closed, merged, or the `deploy` label is removed.

## Additional Notes

<!-- Add any extra context, screenshots, or discussion points here. -->
