### PR TITLE
bugfix: rename on hold client request and update latency alert criteria

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ## Related Issues/Tickets
 
-<!-- List related issues or discussions, such as "Closes #123" or "Related to PADS-456" -->
+<!-- List related issues or discussions, such as "Closes #123" or "Related to ABCD-456" -->
 
 ## Type of Change
 

--- a/infra/instance/modules/api/main.tf
+++ b/infra/instance/modules/api/main.tf
@@ -111,12 +111,15 @@ resource "azurerm_monitor_metric_alert" "app_latency_high" {
   severity            = 2
   window_size         = local.default_window_size
 
-  criteria {
-    metric_namespace = "Microsoft.Web/sites"
-    metric_name      = "HttpResponseTime"
-    aggregation      = "Average"
-    operator         = "GreaterThan"
-    threshold        = 1 # Seconds
+  # Check every minute and only fire if condition persists for 3 consecutive minutes
+  dynamic_criteria {
+    metric_namespace         = "Microsoft.Web/sites"
+    metric_name              = "HttpResponseTime"
+    aggregation              = "Average"
+    operator                 = "GreaterThan"
+    alert_sensitivity        = "Medium"
+    evaluation_total_count   = 4
+    evaluation_failure_count = 4
   }
 
   action {

--- a/infra/instance/modules/api/main.tf
+++ b/infra/instance/modules/api/main.tf
@@ -105,13 +105,13 @@ resource "azurerm_monitor_metric_alert" "app_latency_high" {
   name                = "${var.app_name}-${var.app_env}-${var.instance_name}-${var.module_name}-latency-high"
   resource_group_name = var.resource_group_name
   scopes              = [azurerm_linux_web_app.api.id]
-  description         = "Average response time exceeds 1 second. Possible performance degradation or unresponsive behavior."
+  description         = "Elevated API response time. Possible performance degradation or unresponsive behavior."
   auto_mitigate       = local.default_auto_mitigate
   frequency           = local.default_frequency
   severity            = 2
   window_size         = local.default_window_size
 
-  # Check every minute and only fire if condition persists for 3 consecutive minutes
+  # Check every minute and only fire if condition persists for 4 consecutive minutes
   dynamic_criteria {
     metric_namespace         = "Microsoft.Web/sites"
     metric_name              = "HttpResponseTime"

--- a/src/utils/coding.ts
+++ b/src/utils/coding.ts
@@ -104,9 +104,9 @@ export const CodingDictionary: Record<
     }
   },
   'https://bcgov.github.io/nr-pies/docs/spec/code_system/on_hold_process': {
-    CLIENT_REQUEST: {
-      codeSet: ['CLIENT_REQUEST'],
-      display: 'Client Request'
+    APPLICANT_REQUEST: {
+      codeSet: ['APPLICANT_REQUEST'],
+      display: 'Applicant Request'
     },
     LEGAL_ACTION: {
       codeSet: ['LEGAL_ACTION'],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please fill out the following template to help us review your PR. -->

# Description

<!-- Summarize your changes and the motivation behind them. Reference any related issues. -->
This pull request consists of infrastructure and application-level updates to improve alert reliability and align terminology with domain specifications.

### Infrastructure (Azure)
Modified the **app_latency_high** monitor metric alert in the API module.
*   Transitioned from static `criteria` to `dynamic_criteria` for high latency detection.
*   Configured the alert to use machine learning-driven sensitivity (Medium).
*   Updated the evaluation window to require 4 failures out of 4 evaluation periods, reducing "noisy" alerts caused by transient spikes.

### Application Logic (TypeScript)
Updated the `CodingDictionary` utility to reflect a change in the `on_hold_process` specification.
*   Renamed the `CLIENT_REQUEST` key and code set to `APPLICANT_REQUEST`.
*   Updated the associated display string from "Client Request" to "Applicant Request".

## Related Issues/Tickets

<!-- List related issues or discussions, such as "Closes #123" or "Related to ABCD-456" -->
[PSB-148](https://apps.nrs.gov.bc.ca/int/jira/browse/PSB-148)

## Type of Change

<!-- Please check all that apply: -->

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update

## Checklist

<!-- Please check all that apply: -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my changes locally
- [x] The code builds and passes all tests
- [x] I have updated documentation as needed

## Instance Deployment

<!-- Please check all that apply: -->

- [ ] I require a cloud deployment for testing

> [!NOTE]
> To request for a cloud deployment for testing purposes, add the `deploy` label to this PR.
> Deployments will be removed when the PR is closed, merged, or the `deploy` label is removed.

## Additional Notes

<!-- Add any extra context, screenshots, or discussion points here. -->
Out of band in-situ database changes will be performed in tandem.