### PR TITLE
feat: refactor to native Node uuidv7 implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5375,9 +5375,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,7 @@
         "pg": "8.23.0",
         "pino": "10.3.1",
         "pino-http": "11.0.0",
-        "serve-favicon": "2.5.1",
-        "uuid": "14.0.1"
+        "serve-favicon": "2.5.1"
       },
       "devDependencies": {
         "@commitlint/cli": "21.2.1",
@@ -41,7 +40,7 @@
         "@types/express": "5.0.6",
         "@types/js-yaml": "4.0.9",
         "@types/k6": "2.0.1",
-        "@types/node": "24.13.3",
+        "@types/node": "26.2.0",
         "@types/pg": "8.21.0",
         "@types/qs": "6.15.1",
         "@types/serve-favicon": "2.5.7",
@@ -1354,12 +1353,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/pg": {
@@ -7028,9 +7027,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -7050,19 +7049,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "pg": "8.23.0",
     "pino": "10.3.1",
     "pino-http": "11.0.0",
-    "serve-favicon": "2.5.1",
-    "uuid": "14.0.1"
+    "serve-favicon": "2.5.1"
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
@@ -75,7 +74,7 @@
     "@types/express": "5.0.6",
     "@types/js-yaml": "4.0.9",
     "@types/k6": "2.0.1",
-    "@types/node": "24.13.3",
+    "@types/node": "26.2.0",
     "@types/pg": "8.21.0",
     "@types/qs": "6.15.1",
     "@types/serve-favicon": "2.5.7",

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -1,4 +1,4 @@
-import { v7 as uuidv7 } from 'uuid';
+import { randomUUIDv7 } from 'node:crypto';
 
 import {
   cacheableRead,
@@ -101,7 +101,7 @@ export const findRecordService = (asset: Selectable<PiesAsset>): Promise<PiesRec
       }
 
       return {
-        transaction_id: uuidv7(),
+        transaction_id: randomUUIDv7(),
         version: recordKind.versionId,
         kind: 'Record',
         system_id: asset.systemId,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,11 +1,12 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { cwd } from 'node:process';
-import { validate, version } from 'uuid';
 
 import { getLogger } from './log.ts';
 
 const log = getLogger(import.meta.filename);
+
+const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
  * Performs a deep recursive check to determine if the `rhs` object is a subset of the `lhs` object.
@@ -116,9 +117,9 @@ export function getGitRevision(): string | undefined {
  * @returns Timestamp as a number, or undefined if the UUID is invalid or not version 7.
  */
 export function getUUIDv7Timestamp(uuid: string): number | undefined {
-  if (!validate(uuid) || version(uuid) !== 7) return undefined;
+  if (!UUIDV7_REGEX.test(uuid)) return undefined;
 
-  const hexTimestamp = uuid.replaceAll('-', '').slice(0, 12);
+  const hexTimestamp = uuid.slice(0, 8) + uuid.slice(9, 13);
   return Number.parseInt(hexTimestamp, 16);
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please fill out the following template to help us review your PR. -->

# Description

<!-- Summarize your changes and the motivation behind them. Reference any related issues. -->
This pull request updates how UUIDv7 values are generated and validated in the codebase, removing the dependency on the `uuid` library in favor of built-in Node.js functionality. It also updates the Node.js type definitions and refactors UUIDv7 timestamp extraction logic.

**UUIDv7 generation and validation improvements:**

* Replaced the use of the `uuid` library for generating UUIDv7 with Node.js's built-in `randomUUIDv7` function in `src/services/record.ts`, and removed the `uuid` dependency from `package.json`.
* Added a custom `UUIDV7_REGEX` for validating UUIDv7 format in `src/utils/utils.ts`, and refactored the `getUUIDv7Timestamp` function to use this regex and a simplified parsing approach.

**Dependency updates:**

* Removed the `uuid` package from dependencies in `package.json`, since it is no longer needed.
* Updated the `@types/node` development dependency to version `26.2.0` in `package.json` to ensure compatibility with newer Node.js features.

## Related Issues/Tickets

<!-- List related issues or discussions, such as "Closes #123" or "Related to ABCD-456" -->
[PSB-180](https://apps.nrs.gov.bc.ca/int/jira/browse/PSB-180)

## Type of Change

<!-- Please check all that apply: -->

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update

## Checklist

<!-- Please check all that apply: -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my changes locally
- [x] The code builds and passes all tests
- [x] I have updated documentation as needed

## Instance Deployment

<!-- Please check all that apply: -->

- [ ] I require a cloud deployment for testing

> [!NOTE]
> To request for a cloud deployment for testing purposes, add the `deploy` label to this PR.
> Deployments will be removed when the PR is closed, merged, or the `deploy` label is removed.

## Additional Notes

<!-- Add any extra context, screenshots, or discussion points here. -->
